### PR TITLE
Reschedule the class sessions to free up a week for the university holiday

### DIFF
--- a/syllabus/readme.md
+++ b/syllabus/readme.md
@@ -217,7 +217,7 @@ See assessments folder for details.
 
 Activities and assessments:
 - group assignment 4 due the Sunday before class
-- in-lass midterm exam
+- in-class midterm exam
 
 ## Oct 28 - Social Science and the Scientific Method
 

--- a/syllabus/readme.md
+++ b/syllabus/readme.md
@@ -217,7 +217,7 @@ See assessments folder for details.
 
 Activities and assessments:
 - group assignment 4 due the Sunday before class
-- in class midterm exam
+- in-lass midterm exam
 
 ## Oct 28 - Social Science and the Scientific Method
 

--- a/syllabus/readme.md
+++ b/syllabus/readme.md
@@ -199,14 +199,7 @@ Activities and assessments:
 - prep notes 5 due the Sunday before class
 - in-class problem set 6
 
-## Oct 14 - Spatial Data Workshop
-
-Learning objectives: we practice the spatial data skills from the past couple of weeks.
-
-Activities and assessments:
-- in-class group work for assignment 4
-
-## Oct 21 - Qualitative Methods in Practice
+## Oct 14 - Qualitative Methods in Practice
 
 Learning objectives: we introduce qualitative methods including study design, implementation, qualitative analysis, and the role of qualitative methods in urban planning.
 
@@ -216,14 +209,16 @@ Pre-class prep:
 - Acolin A, Kim AM. 2021. Algorithmic justice and groundtruthing the remote mapping of informal settlements: The example of Ho Chi Minh City's periphery. Environment and Planning B: Urban Analytics and City Science. [Direct link](https://journals.sagepub.com/doi/full/10.1177/2399808321998708)
 
 Activities and assessments:
-- group assignment 4 due the Sunday before class
 - prep notes 6 due the Sunday before class
 
-## Oct 28 - Mid-Term Exam
+## Oct 21 - Mid-Term Exam
 
 See assessments folder for details.
 
-## Nov 4 - Social Science and the Scientific Method
+Activities and assessments:
+- group assignment 4 due the Sunday before class
+
+## Oct 28 - Social Science and the Scientific Method
 
 Learning objectives: we introduce social science, the scientific method, inference, prediction and explanation, and instrumentalism. We discuss the roles of qualitative and quantitative methods in constructing actionable knowledge.
 
@@ -234,7 +229,7 @@ Activities and assessments:
 - prep notes 7 due the Sunday before class
 - in-class problem set 7
 
-## Nov 11 - Inference and Uncertainty
+## Nov 4 - Inference and Uncertainty
 
 Learning objectives: we introduce a statistical framework for hypothesis testing, inference, confidence, and uncertainty. We discuss the limitations of this framework and how other methods, such as qualitative research, can help us build knowledge.
 
@@ -247,6 +242,8 @@ Pre-class prep:
 Activities and assessments:
 - prep notes 8 due the Sunday before class
 - in-class problem set 8
+
+## Nov 11 - No Class, University Holiday
 
 ## Nov 18 - Statistical Models
 

--- a/syllabus/readme.md
+++ b/syllabus/readme.md
@@ -217,6 +217,7 @@ See assessments folder for details.
 
 Activities and assessments:
 - group assignment 4 due the Sunday before class
+- in class midterm exam
 
 ## Oct 28 - Social Science and the Scientific Method
 

--- a/syllabus/readme.md
+++ b/syllabus/readme.md
@@ -244,7 +244,9 @@ Activities and assessments:
 - prep notes 8 due the Sunday before class
 - in-class problem set 8
 
-## Nov 11 - No Class, University Holiday
+## Nov 11 - No Class
+
+University holiday
 
 ## Nov 18 - Statistical Models
 


### PR DESCRIPTION
Changes to the schedule include:

- Removed the Spatial Data Workshop week
- Shifted sessions originally scheduled for Oct 21, Oct 28, Nov 4, and Nov 11, 2025, ahead by one week
- Activities and assessments are updated accordingly, except for the due date for Group Assignment 4
- No class on Nov 11, 2025

@gboeing, could you please review and confirm, especially the due date for Group Assignment 4? I kept it to be the Sunday before the Oct 21 session. If we shift the Group Assignment 4 due date up by a week, as the other parts, there would be only one week between the Group Assignment 3 and 4 due dates.

Once we confirm the class schedules, I will update Brightspace assignments accordingly. Thanks!